### PR TITLE
feature about-and-contact us page

### DIFF
--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -42,11 +42,11 @@ const Navbar = () => {
     },
     {
       name: 'about_us',
-      link: '/',
+      link: '/about',
     },
     {
       name: 'contact_us',
-      link: '/login',
+      link: '/contact_us',
     },
   ];
   return (

--- a/src/components/RouterProvide.jsx
+++ b/src/components/RouterProvide.jsx
@@ -17,6 +17,8 @@ import UserProfile from '../views/userProfile/UserProfile';
 import WishListPage from './wishlist/WishListPage';
 import ValidatedBuyer from '../middlewares/authMiddlewares/ValidatedBuyer';
 import ShopPage from '../views/shoppingPage/shop';
+import ContactPage from '../views/about/ContactPage';
+import AboutPage from '../views/about/AboutPage';
 
 // dotenv.config();
 const RouterProv = () => {
@@ -30,6 +32,8 @@ const RouterProv = () => {
             <Route path="/resetPassword" element={<ResetPassword />} />
             <Route path="/reset" element={<NewPassword />} />
             <Route path="/shop" element={<ShopPage />} />
+            <Route path="/contact_us" element={<ContactPage />} />
+            <Route path="/about" element={<AboutPage />} />
 
             <Route path="/product/:id" element={<SingleProduct />} />
 

--- a/src/views/about/AboutPage.jsx
+++ b/src/views/about/AboutPage.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import NavBar from '../../components/Navbar';
+import Footer from '../../components/FrontFooter';
+
+const AboutPage = () => {
+  return (
+    <>
+      <NavBar />
+      <div>
+        <section className="py-10">
+          <div className="container mx-auto px-4">
+            <h1 className="text-3xl font-bold text-gray-800 m-10 text-center">
+              About Us
+            </h1>
+            <p className="text-gray-700 mb-8 mx-[10vw]">
+              At ALTP Ecommerce, we believe in providing a platform that enables
+              anyone to sell their products easily. Whether you are an
+              individual with unique handmade items or a business looking to
+              expand your online presence, we have got you covered.
+            </p>
+            <h1 className="text-2xl font-normal text-gray-800 mb-4 text-center">
+              Our mission
+            </h1>
+            <p className="text-gray-700 mb-8 mx-[10vw]">
+              Our mission is to connect buyers and sellers from all around the
+              world, fostering a vibrant and diverse online marketplace. We
+              prioritize user experience, security, and transparency, ensuring a
+              seamless and trustworthy shopping experience for all.
+            </p>
+            <p className="text-gray-700 mb-8 mx-[10vw]">
+              <h1 className="text-2xl font-normal text-gray-800 mb-4 text-center">
+                what you can benefit from us
+              </h1>
+              With ALTP Ecommerce, you can set up your own online store, manage
+              your inventory, and reach a wider audience without the
+              complexities of building a website from scratch. We provide a
+              user-friendly interface, powerful tools, and robust backend
+              infrastructure to support your entrepreneurial journey.
+            </p>
+            <p className="text-gray-700 mb-8 mx-[10vw]">
+              Join our community of sellers today and start monetizing your
+              products. Whether itis fashion, electronics, art, or any other
+              category, ALTP Ecommerce is the platform for you. We are excited
+              to have you on board!
+            </p>
+          </div>
+        </section>
+      </div>
+      <Footer />
+    </>
+  );
+};
+export default AboutPage;

--- a/src/views/about/ContactPage.jsx
+++ b/src/views/about/ContactPage.jsx
@@ -1,0 +1,283 @@
+import React from 'react';
+import FormInput from '../../components/formControlscomponents/formInput/FormInput';
+import NavBar from '../../components/Navbar';
+import Footer from '../../components/FrontFooter';
+
+const ContactPage = () => {
+  return (
+    <>
+      <NavBar />
+      <div className="container my-24 px-6 mx-auto">
+        <section className="mb-32 text-gray-800">
+          <div className="flex justify-center">
+            <div className="lg:max-w-3xl md:max-w-xl">
+              <h2 className="text-3xl font-bold mb-12 px-6 -ml-[22vw] md:ml-0">
+                Contact us
+              </h2>
+            </div>
+          </div>
+          <div className="flex flex-col justify-center items-center mb-[5vh]">
+            <h1 className="font-light mr-[30vw] w-2/4 text-gray-600 text-lg">
+              Looking to take your e-commerce business to new heights? Look no
+              further! Introducing ATLP, your ultimate solution for all things
+              e-commerce.
+              <span className="text-slate-900 font-normal">
+                reach out to us possibly via the following
+              </span>
+            </h1>
+          </div>
+          <div className="flex flex-row gap-2 md:flex-wrap">
+            <div className="grow-0 shrink-0 basis-auto mb-12 ml-10 md:ml-0 lg:mb-0 w-3/4 md:w-full lg:w-5/12 px-3 lg:px-6">
+              <form>
+                <div className="form-group mb-6">
+                  <FormInput
+                    type="text"
+                    className="form-control block
+                 w-3/4
+                 md:w-full
+                 px-3
+                 py-1.5
+                 text-base
+                 font-normal
+                 text-gray-700
+                 bg-white bg-clip-padding
+                 border border-solid border-gray-300
+                 rounded
+     
+                 focus:text-gray-700 focus:bg-white focus:border-slate-900 focus:outline-none"
+                    placeholder="Name"
+                  />
+                </div>
+                <div className="form-group mb-6">
+                  <FormInput
+                    type="text"
+                    className="form-control block
+                 w-3/4
+                 md:w-full
+                 px-3
+                 py-1.5
+                 text-base
+                 font-normal
+                 text-gray-700
+                 bg-white bg-clip-padding
+                 border border-solid border-gray-300
+                 rounded
+     
+                 focus:text-gray-700 focus:bg-white focus:border-slate-900 focus:outline-none"
+                    placeholder="email address"
+                  />
+                </div>
+                <div className="form-group mb-6">
+                  <FormInput
+                    type="text"
+                    className="form-control block
+                 w-3/4
+                 md:w-full
+                 px-3
+                 py-1.5
+                 text-base
+                 font-normal
+                 text-gray-700
+                 bg-white bg-clip-padding
+                 border border-solid border-gray-300
+                 rounded
+     
+                 focus:text-gray-700 focus:bg-white focus:border-slate-900 focus:outline-none"
+                    placeholder="phone number"
+                  />
+                </div>
+                <div className="form-group mb-6">
+                  <FormInput
+                    type="text"
+                    className="form-control block
+                 w-3/4
+                 md:w-full
+                 px-3
+                 py-1.5
+                 text-base
+                 font-normal
+                 text-gray-700
+                 bg-white bg-clip-padding
+                 border border-solid border-gray-300
+                 rounded
+
+                 focus:text-gray-700 focus:bg-white focus:border-slate-900 focus:outline-none"
+                    placeholder="Loaction"
+                  />
+                </div>
+                <div className="form-group mb-6">
+                  <textarea
+                    className="
+            form-control
+            block
+            w-3/4
+            md:w-full
+            px-3
+            py-1.5
+            text-base
+            font-normal
+            text-gray-700
+            bg-white bg-clip-padding
+            border border-solid border-gray-300
+            rounded
+            focus:text-gray-700 focus:bg-white focus:border-slate-700 focus:outline-none
+          "
+                    rows="5"
+                    placeholder="Message"
+                  />
+                </div>
+
+                <button
+                  type="submit"
+                  className="
+          w-3/4
+          md:w-full
+          px-2
+          py-2.5
+          bg-slate-700
+          text-white
+          font-medium
+          text-xs
+          leading-tight
+          uppercase
+          rounded
+          shadow-md
+          hover:bg-slate-500 hover:shadow-lg
+          "
+                >
+                  Send Message
+                </button>
+              </form>
+            </div>
+            <div className="grow-0 shrink-0 basis-auto w-1/4 lg:w-7/12">
+              <div className="flex flex-wrap ml-[-10vw] md:ml-0">
+                <div className="mb-12 grow-0 shrink-0 basis-auto w-full  lg:w-6/12 px-3 lg:px-6">
+                  <div className="flex items-start">
+                    <div className="shrink-0">
+                      <div className="p-4 bg-slate-700 rounded-md shadow-md w-14 h-14 flex items-center justify-center">
+                        <svg
+                          aria-hidden="true"
+                          focusable="false"
+                          data-prefix="fas"
+                          data-icon="headset"
+                          className="w-5 text-white"
+                          role="img"
+                          xmlns="http://www.w3.org/2000/svg"
+                          viewBox="0 0 512 512"
+                        >
+                          <path
+                            fill="currentColor"
+                            d="M192 208c0-17.67-14.33-32-32-32h-16c-35.35 0-64 28.65-64 64v48c0 35.35 28.65 64 64 64h16c17.67 0 32-14.33 32-32V208zm176 144c35.35 0 64-28.65 64-64v-48c0-35.35-28.65-64-64-64h-16c-17.67 0-32 14.33-32 32v112c0 17.67 14.33 32 32 32h16zM256 0C113.18 0 4.58 118.83 0 256v16c0 8.84 7.16 16 16 16h16c8.84 0 16-7.16 16-16v-16c0-114.69 93.31-208 208-208s208 93.31 208 208h-.12c.08 2.43.12 165.72.12 165.72 0 23.35-18.93 42.28-42.28 42.28H320c0-26.51-21.49-48-48-48h-32c-26.51 0-48 21.49-48 48s21.49 48 48 48h181.72c49.86 0 90.28-40.42 90.28-90.28V256C507.42 118.83 398.82 0 256 0z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                    <div className="grow ml-6">
+                      <p className="font-bold mb-1">Technical support</p>
+                      <p className="text-gray-500 md:text-xs">
+                        ecommerceandelaproject@gmail.com
+                      </p>
+                      <p className="text-gray-500">+250 234 567 189</p>
+                    </div>
+                  </div>
+                </div>
+                <div className="mb-12 grow-0 shrink-0 basis-auto w-full lg:w-6/12 px-3 lg:px-6">
+                  <div className="flex items-start">
+                    <div className="shrink-0">
+                      <div className="p-4 bg-slate-700 rounded-md shadow-md w-14 h-14 flex items-center justify-center">
+                        <svg
+                          aria-hidden="true"
+                          focusable="false"
+                          data-prefix="fas"
+                          data-icon="dollar-sign"
+                          className="w-3 text-white"
+                          role="img"
+                          xmlns="http://www.w3.org/2000/svg"
+                          viewBox="0 0 288 512"
+                        >
+                          <path
+                            fill="currentColor"
+                            d="M209.2 233.4l-108-31.6C88.7 198.2 80 186.5 80 173.5c0-16.3 13.2-29.5 29.5-29.5h66.3c12.2 0 24.2 3.7 34.2 10.5 6.1 4.1 14.3 3.1 19.5-2l34.8-34c7.1-6.9 6.1-18.4-1.8-24.5C238 74.8 207.4 64.1 176 64V16c0-8.8-7.2-16-16-16h-32c-8.8 0-16 7.2-16 16v48h-2.5C45.8 64-5.4 118.7.5 183.6c4.2 46.1 39.4 83.6 83.8 96.6l102.5 30c12.5 3.7 21.2 15.3 21.2 28.3 0 16.3-13.2 29.5-29.5 29.5h-66.3C100 368 88 364.3 78 357.5c-6.1-4.1-14.3-3.1-19.5 2l-34.8 34c-7.1 6.9-6.1 18.4 1.8 24.5 24.5 19.2 55.1 29.9 86.5 30v48c0 8.8 7.2 16 16 16h32c8.8 0 16-7.2 16-16v-48.2c46.6-.9 90.3-28.6 105.7-72.7 21.5-61.6-14.6-124.8-72.5-141.7z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                    <div className="grow ml-6">
+                      <p className="font-bold mb-1">Sales questions</p>
+                      <p className="text-gray-500 md:text-xs">
+                        ecommerceandelaproject@gmail.com
+                      </p>
+                      <p className="text-gray-500">+250 456 784 189</p>
+                    </div>
+                  </div>
+                </div>
+                <div className="mb-12 grow-0 shrink-0 basis-auto w-full lg:w-6/12 px-3 lg:px-6">
+                  <div className="flex align-start">
+                    <div className="shrink-0">
+                      <div className="p-4 bg-slate-700 rounded-md shadow-md w-14 h-14 flex items-center justify-center">
+                        <svg
+                          aria-hidden="true"
+                          focusable="false"
+                          data-prefix="fas"
+                          data-icon="newspaper"
+                          className="w-5 text-white"
+                          role="img"
+                          xmlns="http://www.w3.org/2000/svg"
+                          viewBox="0 0 576 512"
+                        >
+                          <path
+                            fill="currentColor"
+                            d="M552 64H88c-13.255 0-24 10.745-24 24v8H24c-13.255 0-24 10.745-24 24v272c0 30.928 25.072 56 56 56h472c26.51 0 48-21.49 48-48V88c0-13.255-10.745-24-24-24zM56 400a8 8 0 0 1-8-8V144h16v248a8 8 0 0 1-8 8zm236-16H140c-6.627 0-12-5.373-12-12v-8c0-6.627 5.373-12 12-12h152c6.627 0 12 5.373 12 12v8c0 6.627-5.373 12-12 12zm208 0H348c-6.627 0-12-5.373-12-12v-8c0-6.627 5.373-12 12-12h152c6.627 0 12 5.373 12 12v8c0 6.627-5.373 12-12 12zm-208-96H140c-6.627 0-12-5.373-12-12v-8c0-6.627 5.373-12 12-12h152c6.627 0 12 5.373 12 12v8c0 6.627-5.373 12-12 12zm208 0H348c-6.627 0-12-5.373-12-12v-8c0-6.627 5.373-12 12-12h152c6.627 0 12 5.373 12 12v8c0 6.627-5.373 12-12 12zm0-96H140c-6.627 0-12-5.373-12-12v-40c0-6.627 5.373-12 12-12h360c6.627 0 12 5.373 12 12v40c0 6.627-5.373 12-12 12z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                    <div className="grow ml-6">
+                      <p className="font-bold mb-1">Press</p>
+                      <p className="text-gray-500 md:text-xs">
+                        ecommerceandelaproject@gmail.com
+                      </p>
+                      <p className="text-gray-500">+250 345 234 567</p>
+                    </div>
+                  </div>
+                </div>
+                <div className="mb-12 grow-0 shrink-0 basis-auto w-full lg:w-6/12 px-3 lg:px-6">
+                  <div className="flex align-start">
+                    <div className="shrink-0">
+                      <div className="p-4 bg-slate-700 rounded-md shadow-md w-14 h-14 flex items-center justify-center">
+                        <svg
+                          aria-hidden="true"
+                          focusable="false"
+                          data-prefix="fas"
+                          data-icon="bug"
+                          className="w-5 text-white"
+                          role="img"
+                          xmlns="http://www.w3.org/2000/svg"
+                          viewBox="0 0 512 512"
+                        >
+                          <path
+                            fill="currentColor"
+                            d="M511.988 288.9c-.478 17.43-15.217 31.1-32.653 31.1H424v16c0 21.864-4.882 42.584-13.6 61.145l60.228 60.228c12.496 12.497 12.496 32.758 0 45.255-12.498 12.497-32.759 12.496-45.256 0l-54.736-54.736C345.886 467.965 314.351 480 280 480V236c0-6.627-5.373-12-12-12h-24c-6.627 0-12 5.373-12 12v244c-34.351 0-65.886-12.035-90.636-32.108l-54.736 54.736c-12.498 12.497-32.759 12.496-45.256 0-12.496-12.497-12.496-32.758 0-45.255l60.228-60.228C92.882 378.584 88 357.864 88 336v-16H32.666C15.23 320 .491 306.33.013 288.9-.484 270.816 14.028 256 32 256h56v-58.745l-46.628-46.628c-12.496-12.497-12.496-32.758 0-45.255 12.498-12.497 32.758-12.497 45.256 0L141.255 160h229.489l54.627-54.627c12.498-12.497 32.758-12.497 45.256 0 12.496 12.497 12.496 32.758 0 45.255L424 197.255V256h56c17.972 0 32.484 14.816 31.988 32.9zM257 0c-61.856 0-112 50.144-112 112h224C369 50.144 318.856 0 257 0z"
+                          />
+                        </svg>
+                      </div>
+                    </div>
+                    <div className="grow ml-6">
+                      <p className="font-bold mb-1">Bug report</p>
+                      <p className="text-gray-500 md:text-xs">
+                        ecommerceandelaproject@gmail.com
+                      </p>
+                      <p className="text-gray-500">+250 234-567-89</p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+      </div>
+      <Footer />
+    </>
+  );
+};
+export default ContactPage;


### PR DESCRIPTION

<img width="1428" alt="Screen Shot 2023-05-18 at 22 05 42" src="https://github.com/atlp-rwanda/ecommerce-app-legends-fe/assets/103331579/1b85d66d-60f5-438d-b34a-0f075378e406">
<img width="1409" alt="Screen Shot 2023-05-18 at 22 05 58" src="https://github.com/atlp-rwanda/ecommerce-app-legends-fe/assets/103331579/3a8592ec-eef4-4746-96cb-757ef0a8d22b">
### what were done here?

- create tailwind styled about us page
- create tailwind styled contact us page

### how these can be tested
- clone the repo `https://github.com/atlp-rwanda/ecommerce-app-legends-fe`
-  suitch to the branch `ft-about-contactUs-page`
-  click about menu
-  click contact menu